### PR TITLE
Fix tests to behave correctly when the tests have no parameters

### DIFF
--- a/src/main/scala/codacy/plugins/docker/DockerPlugin.scala
+++ b/src/main/scala/codacy/plugins/docker/DockerPlugin.scala
@@ -67,7 +67,7 @@ class DockerPlugin(val dockerImageName: DockerImageName) extends IResultsPlugin 
       patterns = patterns.map { case pattern =>
         PatternWithParam(
           patternId = PatternId(pattern.patternIdentifier),
-          parameters = Option(pattern.parameters).filterNot(_.isEmpty).map(_.map { case (key, value) =>
+          parameters = pattern.parameters.map(_.map { case (key, value) =>
             Param(
               name = ParamName(key),
               value = value

--- a/src/main/scala/codacy/plugins/docker/Plugin.scala
+++ b/src/main/scala/codacy/plugins/docker/Plugin.scala
@@ -11,7 +11,7 @@ object PluginRequest {
   implicit val requestFmt: Format[PluginRequest] = Json.format[PluginRequest]
 }
 
-case class Pattern(patternIdentifier: String, parameters: Map[String, JsValue])
+case class Pattern(patternIdentifier: String, parameters: Option[Map[String, JsValue]])
 
 case class PluginConfiguration(patterns: Seq[Pattern])
 

--- a/src/main/scala/codacy/plugins/test/DockerHelpers.scala
+++ b/src/main/scala/codacy/plugins/test/DockerHelpers.scala
@@ -15,18 +15,14 @@ object DockerHelpers {
   def toPatterns(toolSpec: ToolSpec): Seq[Pattern] = toolSpec.patterns.map { case patternSpec =>
     val parameters = patternSpec.parameters.map(_.map { param =>
       (param.name.value, param.default)
-    }.toMap).getOrElse(Map.empty)
+    }.toMap)
 
     Pattern(patternSpec.patternId.value, parameters)
   }.toSeq
 
   def toPatterns(patterns: Seq[PatternSimple]): Seq[Pattern] = patterns.map {
     case pattern =>
-      val parameters = pattern.parameters.map { case (name, value) =>
-        (name, value)
-      }
-
-      Pattern(pattern.name, parameters)
+      Pattern(pattern.name, pattern.parameters)
   }
 
   def testFoldersInDocker(dockerImageName: DockerImageName): Seq[Path] = {

--- a/src/main/scala/codacy/plugins/test/TestFilesParser.scala
+++ b/src/main/scala/codacy/plugins/test/TestFilesParser.scala
@@ -17,7 +17,7 @@ object IssueWithLine {
   implicit val formatter = Json.format[IssueWithLine]
 }
 
-case class PatternSimple(name: String, parameters: Map[String, JsValue])
+case class PatternSimple(name: String, parameters: Option[Map[String, JsValue]])
 
 class TestFilesParser(filesDir: File) {
 
@@ -104,14 +104,13 @@ class TestFilesParser(filesDir: File) {
             .flatMap {
               //pattern has no parameters
               case PatternsList(value) => value.split(",").map { pattern =>
-                PatternSimple(pattern.trim, Map())
+                PatternSimple(pattern.trim, None)
               }
 
               case PatternWithParameters(patternIdString, parameters) =>
                 val patternId = patternIdString.trim
                 val params = Try(cleanParameterTypes(Json.parse(parameters))).toOption
                   .flatMap(_.asOpt[Map[String, JsValue]])
-                  .getOrElse(Map.empty)
                 Seq(PatternSimple(patternId, params))
 
               case _ => Seq.empty


### PR DESCRIPTION
Tested for Pylint ESlint and Rubocop, looks good