### PR TITLE
feature: Depend on the new codacy-analysis-core

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,8 +5,9 @@ object Dependencies {
   private val scalatestVersion = "3.0.5"
   lazy val scalaTest = "org.scalatest" %% "scalatest" % scalatestVersion
 
-  private val analysisCoreVersion = "0.1.0-alpha3.4286"
-  lazy val analysisCore = "com.codacy" %% "codacy-analysis-core" % analysisCoreVersion
+  private val analysisCoreVersion = "0.1.0-alpha3.152"
+
+  lazy val analysisCore = "com.codacy" %% "codacy-analysis-core" % analysisCoreVersion  withSources ()
 
   private val commonsIOVersion = "2.4"
   lazy val commonsIO = "commons-io" % "commons-io" % commonsIOVersion

--- a/src/main/scala/codacy/plugins/test/PatternTests.scala
+++ b/src/main/scala/codacy/plugins/test/PatternTests.scala
@@ -27,7 +27,7 @@ object PatternTests extends ITest with CustomMatchers {
     val languages = findLanguages(testSources, dockerImage)
     val dockerTool = createDockerTool(languages, dockerImage)
     val toolDocumentation = new DockerToolDocumentation(dockerTool, new BinaryDockerHelper(useCachedDocs = false))
-    val dockerRunner = new BinaryDockerRunner[Result](dockerTool)
+    val dockerRunner = new BinaryDockerRunner[Result](dockerTool)()
     val runner = new ToolRunner(dockerTool, toolDocumentation, dockerRunner)
     val tools = languages.map(new core.tools.Tool(runner, DockerRunner.defaultRunTimeout)(dockerTool, _))
 

--- a/src/main/scala/codacy/plugins/test/PluginsTests.scala
+++ b/src/main/scala/codacy/plugins/test/PluginsTests.scala
@@ -21,7 +21,7 @@ object PluginsTests extends ITest {
     val dockerTool = createDockerTool(languages, dockerImage)
     val dockerToolDocumentation = new DockerToolDocumentation(dockerTool, new BinaryDockerHelper(useCachedDocs = false))
     val specOpt = dockerToolDocumentation.spec
-    val dockerRunner = new BinaryDockerRunner[Result](dockerTool)
+    val dockerRunner = new BinaryDockerRunner[Result](dockerTool)()
     val runner = new ToolRunner(dockerTool, dockerToolDocumentation, dockerRunner)
 
     specOpt.forall { spec =>


### PR DESCRIPTION
It now reads codacy.tests.noremove as a property to keep the containers for debug