### PR TITLE
fix: Test SQL files FT-6941

### DIFF
--- a/src/main/scala/codacy/plugins/test/TestFilesParser.scala
+++ b/src/main/scala/codacy/plugins/test/TestFilesParser.scala
@@ -62,6 +62,7 @@ class TestFilesParser(filesDir: File) {
                                              Languages.XML -> Seq("<!--"),
                                              Languages.Dockerfile -> Seq("#"),
                                              Languages.PLSQL -> Seq("--", "/*"),
+                                             Languages.SQL -> Seq("--", "/*"),
                                              Languages.JSON -> Seq("//", "/*"),
                                              Languages.Apex -> Seq("//", "/*"),
                                              Languages.Velocity -> Seq("/*"),


### PR DESCRIPTION
By adding support for SQL languages in the test file parser, plugins may
run tests for SQL files.