### PR TITLE
fix: Parallel collection using fork join to prevent failures from docker

### DIFF
--- a/src/main/scala/codacy/plugins/DockerTest.scala
+++ b/src/main/scala/codacy/plugins/DockerTest.scala
@@ -1,11 +1,11 @@
 package codacy.plugins
 
+import java.io.{File => JFile}
 import java.nio.file.Path
 
 import codacy.plugins.test._
-import codacy.plugins.test.multiple.MultipleTests
 import codacy.plugins.test.duplication.DuplicationTests
-import java.io.{File => JFile}
+import codacy.plugins.test.multiple.MultipleTests
 import wvlet.log.{LogFormatter, LogLevel, LogSupport, Logger}
 
 case class Sources(mainSourcePath: Path, directoryPaths: Seq[Path])

--- a/src/main/scala/codacy/plugins/test/ParallelCollectionsUtils.scala
+++ b/src/main/scala/codacy/plugins/test/ParallelCollectionsUtils.scala
@@ -1,0 +1,20 @@
+package codacy.plugins.test
+
+import scala.collection.parallel.ParIterable
+
+object ParallelCollectionsUtils {
+
+  private[this] lazy val calcForkNum: Int = {
+    val cpuCores = Runtime.getRuntime.availableProcessors()
+    if (cpuCores > 2) cpuCores else 1
+  }
+
+  def forkJoinTaskSupport =
+    new scala.collection.parallel.ForkJoinTaskSupport(new java.util.concurrent.ForkJoinPool(calcForkNum))
+
+  def toPar[A](coll: Iterable[A]): ParIterable[A] = {
+    val collPar = coll.par
+    collPar.tasksupport = forkJoinTaskSupport
+    collPar
+  }
+}

--- a/src/main/scala/codacy/plugins/test/duplication/DuplicationTests.scala
+++ b/src/main/scala/codacy/plugins/test/duplication/DuplicationTests.scala
@@ -24,7 +24,8 @@ object DuplicationTests extends ITest {
   def run(docsDirectory: JFile, dockerImage: DockerImage, optArgs: Seq[String]): Boolean = {
     debug(s"Running DuplicationTests:")
     val testsDirectory = docsDirectory.toScala / DockerHelpers.duplicationTestsDirectoryName
-    testsDirectory.list.toList.par
+    ParallelCollectionsUtils
+      .toPar(testsDirectory.list.toList)
       .map { testDirectory =>
         val srcDir = testDirectory / "src"
         val languages = findLanguages(srcDir.toJava, dockerImage)

--- a/src/main/scala/codacy/plugins/test/multiple/MultipleTests.scala
+++ b/src/main/scala/codacy/plugins/test/multiple/MultipleTests.scala
@@ -1,25 +1,21 @@
 package codacy.plugins.test.multiple
 
+import java.io.{File => JFile}
+
+import better.files._
 import codacy.plugins.test._
-import com.codacy.analysis.core.model.{CodacyCfg, Configuration, FileCfg, FileError, FullLocation, Issue, LineLocation}
+import codacy.plugins.test.resultprinter.ResultPrinter
+import com.codacy.analysis.core.model._
 import com.codacy.analysis.core.tools.Tool
+import com.codacy.plugins.api.languages.Languages
 import com.codacy.plugins.api.results.Result
+import com.codacy.plugins.results.PluginResult
 import com.codacy.plugins.results.traits.{DockerToolDocumentation, ToolRunner}
 import com.codacy.plugins.runners.{BinaryDockerRunner, DockerRunner}
 import com.codacy.plugins.utils.BinaryDockerHelper
-import com.codacy.plugins.results.PluginResult
-import better.files._
-import java.io.{File => JFile}
 
-import codacy.plugins.test.resultprinter.ResultPrinter
-
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Properties, Success, Try}
 import scala.xml.XML
-import com.codacy.analysis.core.model.ToolResult
-import com.codacy.analysis.core.model.Location
-import com.codacy.plugins.api.languages.Languages
-
-import scala.util.Properties
 
 object MultipleTests extends ITest {
 
@@ -28,7 +24,8 @@ object MultipleTests extends ITest {
   def run(docsDirectory: JFile, dockerImage: DockerImage, optArgs: Seq[String]): Boolean = {
     debug(s"Running MultipleTests:")
     val multipleTestsDirectory = docsDirectory.toScala / DockerHelpers.multipleTestsDirectoryName
-    multipleTestsDirectory.list.toList.par
+    ParallelCollectionsUtils
+      .toPar(multipleTestsDirectory.list.toList)
       .map { testDirectory =>
         val srcDir = testDirectory / "src"
         // on multiple tests, the language is not validated but required. We used Scala.


### PR DESCRIPTION
When running patterns test, some random failures were happening. 
This was happing because of having too many instantiations of tools and, consequently, too many tools running at the same time (leading to failures on the tools by lack of resources).
By using fork join as parallel method, we can better ensure a maximum of instantiations, preventing this failure. https://docs.scala-lang.org/overviews/parallel-collections/configuration.html