### PR TITLE
fix: Use dynamic linking in native-image

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,10 +23,7 @@ nativeImageOptions ++= Seq("--enable-http",
                            "-H:+AllowIncompleteClasspath",
                            "-H:+ReportExceptionStackTraces",
                            "--no-fallback",
-                           "--report-unsupported-elements-at-runtime") ++ {
-  if (sys.props.get("os.name").contains("Mac OS X")) Seq.empty
-  else Seq("--static")
-}
+                           "--report-unsupported-elements-at-runtime")
 
 // Scalafix
 


### PR DESCRIPTION
The binary started failing in CircleCI with segmentation fault when calling `getpwuid` [here](https://app.circleci.com/pipelines/github/codacy/codacy-gorevive/167/workflows/6a31e79c-c8c5-4fea-8d58-cc904f4b24b0/jobs/699/parallel-runs/0/steps/0-104).
From [a google search](https://sourceware.org/bugzilla/show_bug.cgi?id=12491) it is related to static linked binaries somehow, so we are disabling static linking.