### PR TITLE
bump: Use latest codacy base version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@5.2.0
+  codacy: codacy/base@10.1.1
 references:
   circleci_job: &circleci_job
     docker:
-      - image: circleci/circleci-cli:0.1.5879
+      - image: circleci/circleci-cli:0.1.23334
     working_directory: ~/workdir
 
 jobs:


### PR DESCRIPTION
This bumps `codacy-orbs` to the latest version, which is currently version 10.1.1. 