### PR TITLE
Revert "bump: Use latest codacy base version"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 version: 2.1
 
 orbs:
-  codacy: codacy/base@10.1.1
+  codacy: codacy/base@5.2.0
 references:
   circleci_job: &circleci_job
     docker:
-      - image: circleci/circleci-cli:0.1.23334
+      - image: circleci/circleci-cli:0.1.5879
     working_directory: ~/workdir
 
 jobs:


### PR DESCRIPTION
Reverts codacy/codacy-plugins-test#144

Bumping `codacy-orbs` to version 10.1.1 causes some segmentation faults on `codacy-dartanalyzer`. I am reverting this to avoid any future problems.

EDIT: For some reason, I am not being able to revert this, as it does not get past CI tests.